### PR TITLE
remove template provider and update to 0.12 syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,19 @@
-provider "template" {
-    version = "~> 1.0"
-}
-
-data "template_file" "domain_guid" {
-    template = "${replace(var.domain, ".", "-")}"
+locals {
+    domain_guid = replace(var.domain, ".", "-")
 }
 
 locals {
-    o365_mx   = "${format("10 %s.mail.protection.outlook.com", data.template_file.domain_guid.rendered)}"
+    o365_mx   = format("0 %s.mail.protection.outlook.com", local.domain_guid)
     o365_spf  = "v=spf1 include:spf.protection.outlook.com -all"
-    dkim_dom  = "${format("%s._domainkey.%s.onmicrosoft.com", data.template_file.domain_guid.rendered, var.tenant_name)}"
+    dkim_dom  = format("%s._domainkey.%s.onmicrosoft.com", local.domain_guid, var.tenant_name)
     dkim = [
         {
-            name  = "${format("selector1._domainkey.%s", var.domain)}"
-            value = "${format("selector1-%s", local.dkim_dom)}"
+            name  = format("selector1._domainkey.%s", var.domain)
+            value = format("selector1-%s", local.dkim_dom)
         },
         {
-            name  = "${format("selector2._domainkey.%s", var.domain)}"
-            value = "${format("selector2-%s", local.dkim_dom)}"
+            name  = format("selector2._domainkey.%s", var.domain)
+            value = format("selector2-%s", local.dkim_dom)
         },
     ]
     sfb = [
@@ -59,63 +55,63 @@ locals {
 #################
 
 resource "aws_route53_record" "mx" {
-    count   = "${var.enable_exchange && var.enable_custom_mx < 1 ? 1 : 0}"
+    count   = var.enable_exchange && !var.enable_custom_mx ? 1 : 0
 
-    zone_id = "${var.zone_id}"
+    zone_id = var.zone_id
     name    = ""
-    records = ["${local.o365_mx}"]
+    records = [local.o365_mx]
     type    = "MX"
-    ttl     = "${var.ttl}"
+    ttl     = var.ttl
 }
 
 resource "aws_route53_record" "custom_mx" {
-    count   = "${var.enable_exchange && var.enable_custom_mx && length(var.custom_mx_record) > 0 ? 1 : 0}"
+    count   = var.enable_exchange && var.enable_custom_mx && length(var.custom_mx_record) > 0 ? 1 : 0
 
-    zone_id = "${var.zone_id}"
+    zone_id = var.zone_id
     name    = ""
-    records = ["${var.custom_mx_record}"]
+    records = [var.custom_mx_record]
     type    = "MX"
-    ttl     = "${var.ttl}"
+    ttl     = var.ttl
 }
 
 resource "aws_route53_record" "autodiscover" {
-    count   = "${var.enable_exchange ? 1 : 0}"
+    count   = var.enable_exchange ? 1 : 0
 
-    zone_id = "${var.zone_id}"
+    zone_id = var.zone_id
     name    = "autodiscover"
     records = ["autodiscover.outlook.com"]
     type    = "CNAME"
-    ttl     = "${var.ttl}"
+    ttl     = var.ttl
 }
 
 resource "aws_route53_record" "spf" {
-    count   = "${var.enable_exchange && length(var.ms_txt) > 0 ? 1 : 0}"
+    count   = var.enable_exchange && length(var.ms_txt) > 0 ? 1 : 0
 
-    zone_id = "${var.zone_id}"
+    zone_id = var.zone_id
     name    = ""
     records = ["MS=${var.ms_txt}","${local.o365_spf}"]
     type    = "TXT"
-    ttl     = "${var.ttl}"
+    ttl     = var.ttl
 }
 
 resource "aws_route53_record" "dmarc" {
-    count   = "${var.enable_exchange && var.enable_dmarc && length(var.dmarc_record) > 0 ? 1 : 0}"
+    count   = var.enable_exchange && var.enable_dmarc && length(var.dmarc_record) > 0 ? 1 : 0
 
-    zone_id = "${var.zone_id}"
+    zone_id = var.zone_id
     name    = "_dmarc"
-    records = ["${var.dmarc_record}"]
+    records = [var.dmarc_record]
     type    = "TXT"
-    ttl     = "${var.ttl}"
+    ttl     = var.ttl
 }
 
 resource "aws_route53_record" "dkim" {
-    count   = "${var.enable_exchange && var.enable_dkim && length(var.tenant_name) > 0 ? length(local.dkim) : 0}"
+    count   = var.enable_exchange && var.enable_dkim && length(var.tenant_name) > 0 ? length(local.dkim) : 0
 
-    zone_id = "${var.zone_id}"
-    name    = "${lookup(local.dkim[count.index], "name")}"
-    records = ["${lookup(local.dkim[count.index], "value")}"]
+    zone_id = var.zone_id
+    name    = lookup(local.dkim[count.index], "name")
+    records = [lookup(local.dkim[count.index], "value")]
     type    = "CNAME"
-    ttl     = "${var.ttl}"
+    ttl     = var.ttl
 }
 
 ####################
@@ -123,13 +119,13 @@ resource "aws_route53_record" "dkim" {
 ####################
 
 resource "aws_route53_record" "sfb" {
-    count   = "${var.enable_sfb ? length(local.sfb) : 0}"
+    count   = var.enable_sfb ? length(local.sfb) : 0
 
-    zone_id = "${var.zone_id}"
-    name    = "${lookup(local.sfb[count.index], "name")}"
-    records = ["${lookup(local.sfb[count.index], "record")}"]
-    type    = "${lookup(local.sfb[count.index], "type")}"
-    ttl     = "${var.ttl}"
+    zone_id = var.zone_id
+    name    = lookup(local.sfb[count.index], "name")
+    records = [lookup(local.sfb[count.index], "record")]
+    type    = lookup(local.sfb[count.index], "type")
+    ttl     = var.ttl
 }
 
 ##########################
@@ -137,11 +133,11 @@ resource "aws_route53_record" "sfb" {
 ##########################
 
 resource "aws_route53_record" "mdm" {
-    count   = "${var.enable_mdm ? length(local.mdm) : 0}"
+    count   = var.enable_mdm ? length(local.mdm) : 0
 
-    zone_id = "${var.zone_id}"
-    name    = "${lookup(local.mdm[count.index], "name")}"
-    records = ["${lookup(local.mdm[count.index], "record")}"]
+    zone_id = var.zone_id
+    name    = lookup(local.mdm[count.index], "name")
+    records = [lookup(local.mdm[count.index], "record")]
     type    = "CNAME"
-    ttl     = "${var.ttl}"
+    ttl     = var.ttl
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "mx_record" {
     description = "The DNS name of the specific Office 365 mail server for the domain."
-    value       = "${data.template_file.domain_guid.rendered}.mail.protection.outlook.com}"
+    value       = "${local.domain_guid}.mail.protection.outlook.com}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,13 @@ variable "custom_mx_record" {
     description = "The value of the custom MX record to create."
     default     = ""
 }
+
+variable "enable_spf" {
+    description = "Controls whether SPF should be included in the root TXT record."
+    default     = false
+}
+
+variable "custom_spf_includes" {
+    description = "If SPF is enabled this is a list of extra include statements."
+    default     = []
+}


### PR DESCRIPTION
Thanks for the module! I'm new to terraform but it seems some updates in 0.12 made some of the interpolation unnecessary, and the template provider has changed (seems like that can just be a local).

I also upped the priority of the MX record to 0 (it was 10). Microsoft [docs](https://docs.microsoft.com/en-us/microsoft-365/admin/get-help-with-domains/create-dns-records-at-any-dns-hosting-provider?view=o365-worldwide) indicate `0` as the most common value.